### PR TITLE
Add chStoryUrl to formatCommits() call.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -147,7 +147,7 @@ async function run() {
         head: tag,
       });
 
-      const formattedCommits = formatCommits(commits);
+      const formattedCommits = formatCommits(commits, chStoryUrl);
       changelog = generateChangelog(formattedCommits);
 
       core.info(changelog);

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ export async function run() {
         head: tag,
       });
 
-      const formattedCommits = formatCommits(commits);
+      const formattedCommits = formatCommits(commits, chStoryUrl);
       changelog = generateChangelog(formattedCommits);
 
       core.info(changelog);


### PR DESCRIPTION
Example of the issue on latest website release:
<img width="902" alt="Screen Shot 2020-11-13 at 2 15 22 PM" src="https://user-images.githubusercontent.com/1829422/99111785-b540ce00-25ba-11eb-81de-8d55c9968e6f.png">
