### PR TITLE
Allow any tag format

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -99,7 +99,7 @@ async function run() {
     const ghToken = core.getInput('ghToken');
     const chStoryUrl = core.getInput('chStoryUrl');
     const { ref } = github.context;
-    const tagRegex = /(?<refs>refs)\/(?<tags>tags)\/(?<tag>v\d{2}\.\d+\.\d+)/;
+    const tagRegex = /(?<refs>refs)\/(?<tags>tags)\/(?<tag>.*)/;
     const validTag = ref.match(tagRegex);
 
     if (!ghToken) {
@@ -109,7 +109,7 @@ async function run() {
     core.setSecret('ghToken');
 
     if (!validTag || !validTag.groups.tag) {
-      return core.setFailed('Tag must follow format rules: v##.##.##');
+      return core.setFailed('Ref must be a tag');
     }
 
     const {

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ export async function run() {
     const ghToken = core.getInput('ghToken');
     const chStoryUrl = core.getInput('chStoryUrl');
     const { ref } = github.context;
-    const tagRegex = /(?<refs>refs)\/(?<tags>tags)\/(?<tag>v\d{2}\.\d+\.\d+)/;
+    const tagRegex = /(?<refs>refs)\/(?<tags>tags)\/(?<tag>.*)/;
     const validTag = ref.match(tagRegex);
 
     if (!ghToken) {
@@ -93,7 +93,7 @@ export async function run() {
     core.setSecret('ghToken');
 
     if (!validTag || !validTag.groups.tag) {
-      return core.setFailed('Tag must follow format rules: v##.##.##');
+      return core.setFailed('Ref must be a tag');
     }
 
     const {

--- a/index.test.js
+++ b/index.test.js
@@ -90,7 +90,7 @@ describe('Release', () => {
     });
 
     test("should exit if tag isn't properly formatted", async () => {
-      github.context.ref = 'refs/tags/testing';
+      github.context.ref = 'refs/heads/v20.0.1';
       inputs = {
         createChangelog: 'true',
         chStoryUrl,
@@ -101,9 +101,7 @@ describe('Release', () => {
 
       await run();
 
-      expect(core.setFailed).toHaveBeenCalledWith(
-        'Tag must follow format rules: v##.##.##'
-      );
+      expect(core.setFailed).toHaveBeenCalledWith('Ref must be a tag');
     });
 
     describe('on createChangelog: true', () => {


### PR DESCRIPTION
### Context

This package implemented a restriction on tags being formatted a certain way. Some of our repos don't follow this pattern.

### Analysis

Each project should be able to implement their own desired restrictions as far as tag formatting, and have a number of avenues to do so.

### Solution

We can remove any formatting enforcement from this action.