### PR TITLE
Metadata update for publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# release
+# Clubhouse Release
 
 [![code style:
 prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 ![Test](https://github.com/farmersdog/clubhouse-pr/workflows/Test/badge.svg)
+
+This action creates a formatted release in github from formatted commit messages annotated with clubhouse story data. [Clubhouse PR](https://github.com/marketplace/actions/clubhouse-pr)
+can automatically format your PR titles (and commit messages, once merged) for use with this action.
 
 ## Inputs
 
@@ -20,13 +23,19 @@ Would you like to generate a changelog for this release?
 
 Clubhouse story URL (ie. https://app.clubhouse.io/org/story)
 
+### `tag`
+
+The git tag for the current release.
+
 ### `previousTag`
 
-Github tag of latest release
+The git tag of the most recent prior release.
 
 ### `prerelease`
 
-**Default** true
+Would you like the release be created in the "prereleased" state?
+
+**Default** false
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Release'
-description: 'Create a prerelease/release'
+name: 'Clubhouse Release'
+description: 'Create a formatted release in github from formatted commit messages'
 inputs:
   ghToken:
     description: 'Github token'
@@ -10,12 +10,12 @@ inputs:
     description: 'Would you like to generate a changelog for this release?'
     default: true
   tag:
-    description: 'Github tag'
+    description: 'The git tag for the current release'
     required: true
   previousTag:
-    description: 'The latest tag'
+    description: 'The git tag of the previous release'
   prerelease:
-    description: 'Is this a prerelease?'
+    description: 'Should the release be created in the "prereleased" state?'
     default: true
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -13,10 +13,10 @@ inputs:
     description: 'The git tag for the current release'
     required: true
   previousTag:
-    description: 'The git tag of the previous release'
+    description: 'The git tag of the most recent prior release'
   prerelease:
-    description: 'Should the release be created in the "prereleased" state?'
-    default: true
+    description: 'Would you like the release be created in the "prereleased" state?'
+    default: false
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Github is blocking publishing due to requirements for meetadata in the `action.yml`. Updated the name to be more specific, and corresponding docs.